### PR TITLE
MainView & LoginView : 다이얼로그, 팝오버 - 디자인 수정 & 화면 연결

### DIFF
--- a/ATeen/ATeen.xcodeproj/project.pbxproj
+++ b/ATeen/ATeen.xcodeproj/project.pbxproj
@@ -13,6 +13,14 @@
 		0922B4A22C022C1200375953 /* CustomImageLabelButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0922B4A12C022C1200375953 /* CustomImageLabelButton.swift */; };
 		094F94FB2C12F9900033ED93 /* VerificationCompleteDialogViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 094F94FA2C12F9900033ED93 /* VerificationCompleteDialogViewController.swift */; };
 		094F94FD2C12FFD70033ED93 /* CustomTwoButtonDialogViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 094F94FC2C12FFD70033ED93 /* CustomTwoButtonDialogViewController.swift */; };
+		094F94FF2C130DC80033ED93 /* ExistingUserLoginDialogViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 094F94FE2C130DC80033ED93 /* ExistingUserLoginDialogViewController.swift */; };
+		094F95012C1367360033ED93 /* VerificationCompleteDialogFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 094F95002C1367360033ED93 /* VerificationCompleteDialogFactory.swift */; };
+		094F95032C13673E0033ED93 /* VerificationCompleteDialogCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 094F95022C13673E0033ED93 /* VerificationCompleteDialogCoordinator.swift */; };
+		094F95052C1367E00033ED93 /* VerificationCompleteDialogCoordinator+VerificationCompleteDialogViewControllerCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 094F95042C1367E00033ED93 /* VerificationCompleteDialogCoordinator+VerificationCompleteDialogViewControllerCoordinator.swift */; };
+		094F95072C136EE90033ED93 /* PhoneNumberCoordinator+VerificationCompleteDialogCoordinatorDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 094F95062C136EE90033ED93 /* PhoneNumberCoordinator+VerificationCompleteDialogCoordinatorDelegate.swift */; };
+		094F95092C13731B0033ED93 /* ExistingUserLoginDialogFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 094F95082C13731B0033ED93 /* ExistingUserLoginDialogFactory.swift */; };
+		094F950B2C1373220033ED93 /* ExistingUserLoginDialogCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 094F950A2C1373220033ED93 /* ExistingUserLoginDialogCoordinator.swift */; };
+		094F950D2C1374AD0033ED93 /* ExistingUserLoginDialogCoordinator+ExistingUserLoginDialogViewControllerCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 094F950C2C1374AD0033ED93 /* ExistingUserLoginDialogCoordinator+ExistingUserLoginDialogViewControllerCoordinator.swift */; };
 		09F9EFF02C05C699009DE3A0 /* TermsOfUseViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09F9EFEF2C05C699009DE3A0 /* TermsOfUseViewController.swift */; };
 		09F9EFF22C062199009DE3A0 /* TermsOfUseFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09F9EFF12C062199009DE3A0 /* TermsOfUseFactory.swift */; };
 		09F9EFF42C0621B7009DE3A0 /* TermsOfUseCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09F9EFF32C0621B7009DE3A0 /* TermsOfUseCoordinator.swift */; };
@@ -185,6 +193,14 @@
 		0922B4A12C022C1200375953 /* CustomImageLabelButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomImageLabelButton.swift; sourceTree = "<group>"; };
 		094F94FA2C12F9900033ED93 /* VerificationCompleteDialogViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerificationCompleteDialogViewController.swift; sourceTree = "<group>"; };
 		094F94FC2C12FFD70033ED93 /* CustomTwoButtonDialogViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomTwoButtonDialogViewController.swift; sourceTree = "<group>"; };
+		094F94FE2C130DC80033ED93 /* ExistingUserLoginDialogViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExistingUserLoginDialogViewController.swift; sourceTree = "<group>"; };
+		094F95002C1367360033ED93 /* VerificationCompleteDialogFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerificationCompleteDialogFactory.swift; sourceTree = "<group>"; };
+		094F95022C13673E0033ED93 /* VerificationCompleteDialogCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerificationCompleteDialogCoordinator.swift; sourceTree = "<group>"; };
+		094F95042C1367E00033ED93 /* VerificationCompleteDialogCoordinator+VerificationCompleteDialogViewControllerCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "VerificationCompleteDialogCoordinator+VerificationCompleteDialogViewControllerCoordinator.swift"; sourceTree = "<group>"; };
+		094F95062C136EE90033ED93 /* PhoneNumberCoordinator+VerificationCompleteDialogCoordinatorDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PhoneNumberCoordinator+VerificationCompleteDialogCoordinatorDelegate.swift"; sourceTree = "<group>"; };
+		094F95082C13731B0033ED93 /* ExistingUserLoginDialogFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExistingUserLoginDialogFactory.swift; sourceTree = "<group>"; };
+		094F950A2C1373220033ED93 /* ExistingUserLoginDialogCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExistingUserLoginDialogCoordinator.swift; sourceTree = "<group>"; };
+		094F950C2C1374AD0033ED93 /* ExistingUserLoginDialogCoordinator+ExistingUserLoginDialogViewControllerCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ExistingUserLoginDialogCoordinator+ExistingUserLoginDialogViewControllerCoordinator.swift"; sourceTree = "<group>"; };
 		09F9EFEF2C05C699009DE3A0 /* TermsOfUseViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TermsOfUseViewController.swift; sourceTree = "<group>"; };
 		09F9EFF12C062199009DE3A0 /* TermsOfUseFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TermsOfUseFactory.swift; sourceTree = "<group>"; };
 		09F9EFF32C0621B7009DE3A0 /* TermsOfUseCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TermsOfUseCoordinator.swift; sourceTree = "<group>"; };
@@ -532,7 +548,6 @@
 			children = (
 				41A014792C070F220046856B /* SignUpViewController.swift */,
 				41DC1A202C077E540035ED4C /* SelectBirthViewController.swift */,
-				094F94FA2C12F9900033ED93 /* VerificationCompleteDialogViewController.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -1110,6 +1125,13 @@
 				41D0F72A2C09A61600488C18 /* PhoneNumberCoordinator.swift */,
 				41D0F72C2C09A7A100488C18 /* PhoneNumberCoordinator+PhoneNumberViewControllerCoordinator.swift */,
 				41D0F7362C09BEC600488C18 /* PhoneNumberCoordinator+TermsOfUseCoordinatorDelegate.swift */,
+				094F95062C136EE90033ED93 /* PhoneNumberCoordinator+VerificationCompleteDialogCoordinatorDelegate.swift */,
+				094F95002C1367360033ED93 /* VerificationCompleteDialogFactory.swift */,
+				094F95022C13673E0033ED93 /* VerificationCompleteDialogCoordinator.swift */,
+				094F95042C1367E00033ED93 /* VerificationCompleteDialogCoordinator+VerificationCompleteDialogViewControllerCoordinator.swift */,
+				094F95082C13731B0033ED93 /* ExistingUserLoginDialogFactory.swift */,
+				094F950A2C1373220033ED93 /* ExistingUserLoginDialogCoordinator.swift */,
+				094F950C2C1374AD0033ED93 /* ExistingUserLoginDialogCoordinator+ExistingUserLoginDialogViewControllerCoordinator.swift */,
 			);
 			path = Composition;
 			sourceTree = "<group>";
@@ -1118,6 +1140,8 @@
 			isa = PBXGroup;
 			children = (
 				41D0F7262C09A46B00488C18 /* PhoneNumberViewController.swift */,
+				094F94FA2C12F9900033ED93 /* VerificationCompleteDialogViewController.swift */,
+				094F94FE2C130DC80033ED93 /* ExistingUserLoginDialogViewController.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -1390,6 +1414,7 @@
 				735AC9102C005B5D004C3D21 /* CustomQuestionTextView.swift in Sources */,
 				09F9F0022C09CF33009DE3A0 /* CustomUsedToReportViewButton.swift in Sources */,
 				41BB4C052BFBADDA00D26A5D /* ParentCoordinator.swift in Sources */,
+				094F950D2C1374AD0033ED93 /* ExistingUserLoginDialogCoordinator+ExistingUserLoginDialogViewControllerCoordinator.swift in Sources */,
 				417286D72BFF0D16004F88F9 /* ChatCoordinator.swift in Sources */,
 				73BB940E2C0480D700687A97 /* MainTabCoordinator+LogInCoordinatorDelegate.swift in Sources */,
 				41735B502BFCEC4A00E4A339 /* NavigationImp+UIAdaptivePresentationControllerDelegate.swift in Sources */,
@@ -1411,6 +1436,7 @@
 				09F9EFF22C062199009DE3A0 /* TermsOfUseFactory.swift in Sources */,
 				73BE23232C0DFDF9009A8FC6 /* SearchSchoolCollectionViewCell.swift in Sources */,
 				735AC9182C005BAD004C3D21 /* ProfileDetailViewController.swift in Sources */,
+				094F95032C13673E0033ED93 /* VerificationCompleteDialogCoordinator.swift in Sources */,
 				73F9B8282C021E7800684152 /* ProfileDetailViewModel.swift in Sources */,
 				735AC9032C005AB9004C3D21 /* AnotherTeenTableViewCell.swift in Sources */,
 				417286FB2BFF91D0004F88F9 /* LogInCoordinator+LogInViewControllerCoordinator.swift in Sources */,
@@ -1429,6 +1455,7 @@
 				09F9EFFA2C09A254009DE3A0 /* CustomConfirmDialogViewController.swift in Sources */,
 				09F9F01D2C0D9571009DE3A0 /* ReportCompleteDialogCoordinator+ReportCompleteDialogViewControllerCoordinator.swift in Sources */,
 				417286E42BFF1FDC004F88F9 /* RankingCoordinator.swift in Sources */,
+				094F94FF2C130DC80033ED93 /* ExistingUserLoginDialogViewController.swift in Sources */,
 				418CB1D12BF71CAD001DA795 /* LogInCoordinator.swift in Sources */,
 				41DC1A1D2C077DE60035ED4C /* CustomBirthButton.swift in Sources */,
 				417286CC2BFF0B03004F88F9 /* ProfileFactory.swift in Sources */,
@@ -1440,9 +1467,11 @@
 				417286D32BFF0CE4004F88F9 /* ChatViewContoller.swift in Sources */,
 				418CB1E92BF73E4C001DA795 /* SettingsViewModel.swift in Sources */,
 				735AC8FF2C005AB9004C3D21 /* CategoryTournamentCollectionViewCell.swift in Sources */,
+				094F95012C1367360033ED93 /* VerificationCompleteDialogFactory.swift in Sources */,
 				419CCE862C04C88E00D2E7F8 /* TabTag.swift in Sources */,
 				4190F8C72BF4E6EF00FCC0A3 /* SceneDelegate.swift in Sources */,
 				73F9B82A2C02331400684152 /* MainCoordinator+ProfileCoordinatorDelegate.swift in Sources */,
+				094F95052C1367E00033ED93 /* VerificationCompleteDialogCoordinator+VerificationCompleteDialogViewControllerCoordinator.swift in Sources */,
 				09F9F0082C0C63C3009DE3A0 /* CustomPopoverButton.swift in Sources */,
 				735AC92B2C005D21004C3D21 /* TodayTeen.swift in Sources */,
 				09F9F0062C0C5FBC009DE3A0 /* ReportCompleteDialogViewController.swift in Sources */,
@@ -1485,6 +1514,7 @@
 				736D18E62C078C18003A2243 /* SignUpCoordinator+SelectBirthCoordinatorDelegate.swift in Sources */,
 				418CB1E52BF73CE3001DA795 /* ItemSettingViewModel.swift in Sources */,
 				41A014802C0710D50046856B /* TermsOfUseCoordinator+TermsOfUseViewControllerCoordinator.swift in Sources */,
+				094F95072C136EE90033ED93 /* PhoneNumberCoordinator+VerificationCompleteDialogCoordinatorDelegate.swift in Sources */,
 				41A8F3BF2BFE52E30092CBFA /* CustomTabBarButton.swift in Sources */,
 				418CB1EF2BF740F6001DA795 /* Reusable.swift in Sources */,
 				417286EB2BFF2004004F88F9 /* MainCoordinator.swift in Sources */,
@@ -1495,6 +1525,7 @@
 				736D18E82C07968F003A2243 /* Notification+Name.swift in Sources */,
 				417286FD2BFF93A4004F88F9 /* ProfileCoordinator+ProfileViewControllerCoordinator.swift in Sources */,
 				417286E12BFF1FCA004F88F9 /* RankingFactory.swift in Sources */,
+				094F95092C13731B0033ED93 /* ExistingUserLoginDialogFactory.swift in Sources */,
 				41D0F7222C099BA600488C18 /* TermsOfUseCoordinator+SignUpCoordinatorDelegate.swift in Sources */,
 				41D0F7272C09A46B00488C18 /* PhoneNumberViewController.swift in Sources */,
 				736D18E22C078914003A2243 /* SelectBirthFactory.swift in Sources */,
@@ -1505,6 +1536,7 @@
 				41D0F7292C09A60E00488C18 /* PhoneNumberFactory.swift in Sources */,
 				418CB1EB2BF73E6F001DA795 /* SettingsViewController.swift in Sources */,
 				73F9B8262C02182C00684152 /* ProfileDetailCoordinator.swift in Sources */,
+				094F950B2C1373220033ED93 /* ExistingUserLoginDialogCoordinator.swift in Sources */,
 				41D0F72F2C09AAB200488C18 /* LogInCoordinator+PhoneNumberCoordinatorDelegate.swift in Sources */,
 				735AC9352C005EB0004C3D21 /* MainCoordinator+MainViewControllerCoordinator.swift in Sources */,
 				09F9F0002C09B1E7009DE3A0 /* ReportDialogViewController.swift in Sources */,

--- a/ATeen/ATeen.xcodeproj/project.pbxproj
+++ b/ATeen/ATeen.xcodeproj/project.pbxproj
@@ -11,6 +11,8 @@
 		0444E85C2C075DE700FB96FD /* SnapKit-Dynamic in Embed Frameworks */ = {isa = PBXBuildFile; productRef = 0444E8592C075DE700FB96FD /* SnapKit-Dynamic */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		0444E85D2C0760EE00FB96FD /* SnapKit-Dynamic in Frameworks */ = {isa = PBXBuildFile; productRef = 0444E8592C075DE700FB96FD /* SnapKit-Dynamic */; };
 		0922B4A22C022C1200375953 /* CustomImageLabelButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0922B4A12C022C1200375953 /* CustomImageLabelButton.swift */; };
+		094F94FB2C12F9900033ED93 /* VerificationCompleteDialogViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 094F94FA2C12F9900033ED93 /* VerificationCompleteDialogViewController.swift */; };
+		094F94FD2C12FFD70033ED93 /* CustomTwoButtonDialogViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 094F94FC2C12FFD70033ED93 /* CustomTwoButtonDialogViewController.swift */; };
 		09F9EFF02C05C699009DE3A0 /* TermsOfUseViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09F9EFEF2C05C699009DE3A0 /* TermsOfUseViewController.swift */; };
 		09F9EFF22C062199009DE3A0 /* TermsOfUseFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09F9EFF12C062199009DE3A0 /* TermsOfUseFactory.swift */; };
 		09F9EFF42C0621B7009DE3A0 /* TermsOfUseCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09F9EFF32C0621B7009DE3A0 /* TermsOfUseCoordinator.swift */; };
@@ -181,6 +183,8 @@
 
 /* Begin PBXFileReference section */
 		0922B4A12C022C1200375953 /* CustomImageLabelButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomImageLabelButton.swift; sourceTree = "<group>"; };
+		094F94FA2C12F9900033ED93 /* VerificationCompleteDialogViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerificationCompleteDialogViewController.swift; sourceTree = "<group>"; };
+		094F94FC2C12FFD70033ED93 /* CustomTwoButtonDialogViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomTwoButtonDialogViewController.swift; sourceTree = "<group>"; };
 		09F9EFEF2C05C699009DE3A0 /* TermsOfUseViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TermsOfUseViewController.swift; sourceTree = "<group>"; };
 		09F9EFF12C062199009DE3A0 /* TermsOfUseFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TermsOfUseFactory.swift; sourceTree = "<group>"; };
 		09F9EFF32C0621B7009DE3A0 /* TermsOfUseCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TermsOfUseCoordinator.swift; sourceTree = "<group>"; };
@@ -355,6 +359,7 @@
 			children = (
 				0922B4A12C022C1200375953 /* CustomImageLabelButton.swift */,
 				09F9EFF92C09A254009DE3A0 /* CustomConfirmDialogViewController.swift */,
+				094F94FC2C12FFD70033ED93 /* CustomTwoButtonDialogViewController.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -527,6 +532,7 @@
 			children = (
 				41A014792C070F220046856B /* SignUpViewController.swift */,
 				41DC1A202C077E540035ED4C /* SelectBirthViewController.swift */,
+				094F94FA2C12F9900033ED93 /* VerificationCompleteDialogViewController.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -1379,6 +1385,7 @@
 				735AC9152C005B9F004C3D21 /* CustomHeartButton.swift in Sources */,
 				418CB1F42BF743AE001DA795 /* SettingsCoordinator.swift in Sources */,
 				41735B4C2BFCE8E300E4A339 /* SettingsCoordinator+UserConfigurationCoordinatorDelegate.swift in Sources */,
+				094F94FB2C12F9900033ED93 /* VerificationCompleteDialogViewController.swift in Sources */,
 				41A515A62C022B3000EDAEA2 /* ProfileDetailBottomBar.swift in Sources */,
 				735AC9102C005B5D004C3D21 /* CustomQuestionTextView.swift in Sources */,
 				09F9F0022C09CF33009DE3A0 /* CustomUsedToReportViewButton.swift in Sources */,
@@ -1442,6 +1449,7 @@
 				73BE23202C0DFD5D009A8FC6 /* SearchSchoolResultTableViewCell.swift in Sources */,
 				736D18DE2C0787AC003A2243 /* SignUpCoordinator+SignUpViewControllerCoordinator.swift in Sources */,
 				417286CE2BFF0B83004F88F9 /* ProfileCoordinator.swift in Sources */,
+				094F94FD2C12FFD70033ED93 /* CustomTwoButtonDialogViewController.swift in Sources */,
 				417286CA2BFF0AEA004F88F9 /* ProfileViewController.swift in Sources */,
 				41BB4C0B2BFBB8BE00D26A5D /* UserConfigurationViewController.swift in Sources */,
 				41A0147A2C070F220046856B /* SignUpViewController.swift in Sources */,

--- a/ATeen/ATeen.xcodeproj/project.pbxproj
+++ b/ATeen/ATeen.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		094F95092C13731B0033ED93 /* ExistingUserLoginDialogFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 094F95082C13731B0033ED93 /* ExistingUserLoginDialogFactory.swift */; };
 		094F950B2C1373220033ED93 /* ExistingUserLoginDialogCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 094F950A2C1373220033ED93 /* ExistingUserLoginDialogCoordinator.swift */; };
 		094F950D2C1374AD0033ED93 /* ExistingUserLoginDialogCoordinator+ExistingUserLoginDialogViewControllerCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 094F950C2C1374AD0033ED93 /* ExistingUserLoginDialogCoordinator+ExistingUserLoginDialogViewControllerCoordinator.swift */; };
+		094F950F2C14B82F0033ED93 /* PhoneNumberCoordinator+ExistingUserLoginDialogCoordinatorDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 094F950E2C14B82F0033ED93 /* PhoneNumberCoordinator+ExistingUserLoginDialogCoordinatorDelegate.swift */; };
 		09F9EFF02C05C699009DE3A0 /* TermsOfUseViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09F9EFEF2C05C699009DE3A0 /* TermsOfUseViewController.swift */; };
 		09F9EFF22C062199009DE3A0 /* TermsOfUseFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09F9EFF12C062199009DE3A0 /* TermsOfUseFactory.swift */; };
 		09F9EFF42C0621B7009DE3A0 /* TermsOfUseCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09F9EFF32C0621B7009DE3A0 /* TermsOfUseCoordinator.swift */; };
@@ -201,6 +202,7 @@
 		094F95082C13731B0033ED93 /* ExistingUserLoginDialogFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExistingUserLoginDialogFactory.swift; sourceTree = "<group>"; };
 		094F950A2C1373220033ED93 /* ExistingUserLoginDialogCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExistingUserLoginDialogCoordinator.swift; sourceTree = "<group>"; };
 		094F950C2C1374AD0033ED93 /* ExistingUserLoginDialogCoordinator+ExistingUserLoginDialogViewControllerCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ExistingUserLoginDialogCoordinator+ExistingUserLoginDialogViewControllerCoordinator.swift"; sourceTree = "<group>"; };
+		094F950E2C14B82F0033ED93 /* PhoneNumberCoordinator+ExistingUserLoginDialogCoordinatorDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PhoneNumberCoordinator+ExistingUserLoginDialogCoordinatorDelegate.swift"; sourceTree = "<group>"; };
 		09F9EFEF2C05C699009DE3A0 /* TermsOfUseViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TermsOfUseViewController.swift; sourceTree = "<group>"; };
 		09F9EFF12C062199009DE3A0 /* TermsOfUseFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TermsOfUseFactory.swift; sourceTree = "<group>"; };
 		09F9EFF32C0621B7009DE3A0 /* TermsOfUseCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TermsOfUseCoordinator.swift; sourceTree = "<group>"; };
@@ -1126,6 +1128,7 @@
 				41D0F72C2C09A7A100488C18 /* PhoneNumberCoordinator+PhoneNumberViewControllerCoordinator.swift */,
 				41D0F7362C09BEC600488C18 /* PhoneNumberCoordinator+TermsOfUseCoordinatorDelegate.swift */,
 				094F95062C136EE90033ED93 /* PhoneNumberCoordinator+VerificationCompleteDialogCoordinatorDelegate.swift */,
+				094F950E2C14B82F0033ED93 /* PhoneNumberCoordinator+ExistingUserLoginDialogCoordinatorDelegate.swift */,
 				094F95002C1367360033ED93 /* VerificationCompleteDialogFactory.swift */,
 				094F95022C13673E0033ED93 /* VerificationCompleteDialogCoordinator.swift */,
 				094F95042C1367E00033ED93 /* VerificationCompleteDialogCoordinator+VerificationCompleteDialogViewControllerCoordinator.swift */,
@@ -1501,6 +1504,7 @@
 				735AC9012C005AB9004C3D21 /* CategoryTodayCollectionViewCell.swift in Sources */,
 				41D0F72B2C09A61600488C18 /* PhoneNumberCoordinator.swift in Sources */,
 				0922B4A22C022C1200375953 /* CustomImageLabelButton.swift in Sources */,
+				094F950F2C14B82F0033ED93 /* PhoneNumberCoordinator+ExistingUserLoginDialogCoordinatorDelegate.swift in Sources */,
 				418CB2072BF74E88001DA795 /* TeenViewController.swift in Sources */,
 				09F9EFFD2C09A3DC009DE3A0 /* CustomLoginButton.swift in Sources */,
 				09F9F0042C0B0BD1009DE3A0 /* ReportPopoverViewController.swift in Sources */,

--- a/ATeen/ATeen/Common/Components/CustomConfirmDialogViewController.swift
+++ b/ATeen/ATeen/Common/Components/CustomConfirmDialogViewController.swift
@@ -120,7 +120,11 @@ class CustomConfirmDialogViewController: UIViewController {
         }
         
         messageLabel.snp.makeConstraints { make in
-            make.top.equalTo(titleLabel.snp.bottom).offset(10)
+            if dialogTitle == nil {
+                make.top.equalToSuperview().offset(50)
+            } else {
+                make.top.equalTo(titleLabel.snp.bottom).offset(10)
+            }
             make.centerX.equalToSuperview()
         }
         

--- a/ATeen/ATeen/Common/Components/CustomTwoButtonDialogViewController.swift
+++ b/ATeen/ATeen/Common/Components/CustomTwoButtonDialogViewController.swift
@@ -1,0 +1,194 @@
+//
+//  CustomTwoButtonDialogViewController.swift
+//  ATeen
+//
+//  Created by phang on 6/7/24.
+//
+
+import SnapKit
+
+import UIKit
+
+class CustomTwoButtonDialogViewController: UIViewController {
+    var dialogImage: UIImage?
+    var dialogTitle: String?
+    var titleColor: UIColor
+    var titleNumberOfLine: Int
+    var titleFont: UIFont
+    var dialogMessage: String
+    var messageColor: UIColor
+    var messageNumberOfLine: Int
+    var messageFont: UIFont
+    var leftButtonText: String
+    var leftButtonColor: UIColor
+    var rightButtonText: String
+    var rightButtonColor: UIColor
+    
+    // MARK: - Private properties
+    private lazy var dialogView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .white
+        view.layer.cornerRadius = ViewValues.defaultRadius
+        return view
+    }()
+    
+    private lazy var dialogImageView: UIImageView = {
+        let imageView = UIImageView()
+        // TODO: -
+        return imageView
+    }()
+    
+    private lazy var titleLabel: UILabel = {
+        let label = UILabel()
+        label.text = dialogTitle
+        label.textColor = titleColor
+        label.textAlignment = .center
+        label.numberOfLines = titleNumberOfLine
+        label.font = titleFont
+        return label
+    }()
+    
+    private lazy var messageLabel: UILabel = {
+        let label = UILabel()
+        label.text = dialogMessage
+        label.textColor = messageColor
+        label.textAlignment = .center
+        label.numberOfLines = messageNumberOfLine
+        label.font = messageFont
+        return label
+    }()
+    
+    private lazy var leftButton: UIButton = {
+        let button = UIButton()
+        button.titleLabel?.font = UIFont.customFont(forTextStyle: .callout,
+                                                    weight: .regular)
+        button.setTitle(leftButtonText, for: .normal)
+        button.setTitleColor(.white, for: .normal)
+        button.backgroundColor = leftButtonColor
+        button.layer.cornerRadius = ViewValues.defaultRadius
+        return button
+    }()
+    
+    private lazy var rightButton: UIButton = {
+        let button = UIButton()
+        button.titleLabel?.font = UIFont.customFont(forTextStyle: .callout,
+                                                    weight: .bold)
+        button.setTitle(rightButtonText, for: .normal)
+        button.setTitleColor(.white, for: .normal)
+        button.backgroundColor = rightButtonColor
+        button.layer.cornerRadius = ViewValues.defaultRadius
+        return button
+    }()
+    
+    private lazy var buttonStackView: UIStackView = {
+        let stack = UIStackView(arrangedSubviews: [leftButton, rightButton])
+        stack.axis = .horizontal
+        stack.distribution = .fill
+        stack.spacing = ViewValues.defaultSpacing
+        return stack
+    }()
+    
+    // MARK: - Life Cycle
+    init(
+        dialogImage: UIImage? = nil,
+        dialogTitle: String? = nil,
+        titleColor: UIColor = .black,
+        titleNumberOfLine: Int,
+        titleFont: UIFont = .customFont(forTextStyle: .callout, weight: .bold),
+        dialogMessage: String,
+        messageColor: UIColor = .gray02,
+        messageNumberOfLine: Int,
+        messageFont: UIFont = .customFont(forTextStyle: .footnote, weight: .regular),
+        leftButtonText: String,
+        leftButtonColor: UIColor,
+        rightButtonText: String,
+        rightButtonColor: UIColor
+    ) {
+        self.dialogImage = dialogImage
+        self.dialogTitle = dialogTitle
+        self.titleColor = titleColor
+        self.titleNumberOfLine = titleNumberOfLine
+        self.titleFont = titleFont
+        self.dialogMessage = dialogMessage
+        self.messageColor = messageColor
+        self.messageNumberOfLine = messageNumberOfLine
+        self.messageFont = messageFont
+        self.leftButtonText = leftButtonText
+        self.leftButtonColor = leftButtonColor
+        self.rightButtonText = rightButtonText
+        self.rightButtonColor = rightButtonColor
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        configUserInterface()
+        configLayout()
+        setupActions()
+    }
+    
+    // MARK: - Helpers
+    private func configUserInterface() {
+        view.backgroundColor = .black.withAlphaComponent(0.5)
+
+        view.addSubview(dialogView)
+//        dialogView.addSubview(dialogImageView)
+        dialogView.addSubview(titleLabel)
+        dialogView.addSubview(messageLabel)
+        dialogView.addSubview(leftButton)
+        dialogView.addSubview(rightButton)
+    }
+    
+    private func configLayout() {
+        dialogView.snp.makeConstraints { make in
+            make.leading.equalToSuperview().offset(ViewValues.defaultPadding)
+            make.trailing.equalToSuperview().offset(-ViewValues.defaultPadding)
+            make.center.equalToSuperview()
+        }
+        
+        titleLabel.snp.makeConstraints { make in
+            make.top.equalToSuperview().offset(50)
+            make.centerX.equalToSuperview()
+        }
+        
+        messageLabel.snp.makeConstraints { make in
+            make.top.equalTo(titleLabel.snp.bottom).offset(10)
+            make.centerX.equalToSuperview()
+        }
+        
+        leftButton.snp.makeConstraints { make in
+            make.width.equalTo(ViewValues.width - 32 - 32 * 0.44)
+        }
+        
+        buttonStackView.snp.makeConstraints { make in
+            make.top.equalTo(messageLabel.snp.bottom).offset(25)
+            make.leading.equalToSuperview().offset(ViewValues.defaultPadding)
+            make.trailing.equalToSuperview().offset(-ViewValues.defaultPadding)
+            make.centerX.equalToSuperview()
+            make.bottom.equalToSuperview().offset(-20)
+            make.height.equalTo(50)
+        }
+    }
+    
+    private func setupActions() {
+        leftButton.addTarget(self,
+                                action: #selector(clickLeftButton(_:)),
+                                for: .touchUpInside)
+        rightButton.addTarget(self,
+                                action: #selector(clickRightButton(_:)),
+                                for: .touchUpInside)
+    }
+    
+    // MARK: - Actions
+    @objc func clickLeftButton(_ sender: UIButton) {
+        // overriding 해서 사용
+    }
+    
+    @objc func clickRightButton(_ sender: UIButton) {
+        // overriding 해서 사용
+    }
+}

--- a/ATeen/ATeen/Common/Components/CustomTwoButtonDialogViewController.swift
+++ b/ATeen/ATeen/Common/Components/CustomTwoButtonDialogViewController.swift
@@ -140,7 +140,7 @@ class CustomTwoButtonDialogViewController: UIViewController {
         dialogView.addSubview(titleLabel)
         dialogView.addSubview(messageLabel)
         dialogView.addSubview(leftButton)
-        dialogView.addSubview(rightButton)
+        dialogView.addSubview(buttonStackView)
     }
     
     private func configLayout() {
@@ -156,12 +156,16 @@ class CustomTwoButtonDialogViewController: UIViewController {
         }
         
         messageLabel.snp.makeConstraints { make in
-            make.top.equalTo(titleLabel.snp.bottom).offset(10)
+            if dialogTitle == nil {
+                make.top.equalToSuperview().offset(50)
+            } else {
+                make.top.equalTo(titleLabel.snp.bottom).offset(10)
+            }
             make.centerX.equalToSuperview()
         }
         
         leftButton.snp.makeConstraints { make in
-            make.width.equalTo(ViewValues.width - 32 - 32 * 0.44)
+            make.width.equalTo((ViewValues.width - 32 - 32 - 16) * 0.44)
         }
         
         buttonStackView.snp.makeConstraints { make in

--- a/ATeen/ATeen/Common/Localize/AppLocalized.swift
+++ b/ATeen/ATeen/Common/Localize/AppLocalized.swift
@@ -18,6 +18,7 @@ enum AppLocalized {
     static let voteButton = "투표하기"
     static let loginButton = "로그인"
     static let nextButton = "다음으로"
+    static let reportButton = "신고하기"
     
     // MARK: - AboutATeenTableViewCell
     static let teenTitle = "Teen"
@@ -76,5 +77,14 @@ enum AppLocalized {
     static let inputCodeText = "6자리 코드 입력"
     static let resendText = "코드를 받지 못하셨나요? 다시 전송해보세요!"
     static let resendButtonText = "다시 전송하기"
-    
+
+    // MARK: - MainView / Report
+    static let reportDialogTitle = "신고 사유"
+    static let reportDialogViolenceReason = "폭력성 또는 선정적인 프로필"
+    static let reportDialogAdReason = "광고 게시물 또는 프로필"
+    static let reportDialogImpersonationReason = "타인을 사칭한 프로필"
+    static let reportDialogETCReason = "기타"
+    static let reportDialogPlaceholderText = "신고 사유를 작성해주세요."
+    static let reportDialogBlockButtonText = "해당 프로필 다시는 보지 않기"
+    static let reportDialogExplainText = "신고는 반대 의견을 표시하는 기능이 아닙니다."
 }

--- a/ATeen/ATeen/Common/Localize/AppLocalized.swift
+++ b/ATeen/ATeen/Common/Localize/AppLocalized.swift
@@ -19,6 +19,10 @@ enum AppLocalized {
     static let loginButton = "로그인"
     static let nextButton = "다음으로"
     static let reportButton = "신고하기"
+    static let blockButton = "차단하기"
+    static let okButton = "알겠어요!"
+    static let okGoodButton = "좋아요!"
+    static let noButton = "아니요"
     
     // MARK: - AboutATeenTableViewCell
     static let teenTitle = "Teen"
@@ -77,6 +81,15 @@ enum AppLocalized {
     static let inputCodeText = "6자리 코드 입력"
     static let resendText = "코드를 받지 못하셨나요? 다시 전송해보세요!"
     static let resendButtonText = "다시 전송하기"
+    
+    // MARK: - Login / PhoneNumber / Dialogs
+    static let verificationCompleteDialogTitle = "인증이 완료되었어요!"
+    static let verificationCompleteDialogMessage = """
+                                                A-TEEN에 정보를 입력하여
+                                                가입을 마저 완료해보세요.
+                                                """
+    static let existingUserDialogTitle = "이미 가입된 사용자에요!"
+    static let existingUserDialogMessage = "바로 로그인 할까요?"
 
     // MARK: - MainView / Report
     static let reportDialogTitle = "신고 사유"
@@ -87,4 +100,5 @@ enum AppLocalized {
     static let reportDialogPlaceholderText = "신고 사유를 작성해주세요."
     static let reportDialogBlockButtonText = "해당 프로필 다시는 보지 않기"
     static let reportDialogExplainText = "신고는 반대 의견을 표시하는 기능이 아닙니다."
+    static let reportCompleteDialogTitle = "신고가 완료되었습니다."
 }

--- a/ATeen/ATeen/Composition/Coordinator/AppCoordinator/AppCoordinator.swift
+++ b/ATeen/ATeen/Composition/Coordinator/AppCoordinator/AppCoordinator.swift
@@ -34,19 +34,6 @@ final class AppCoordinator: Coordinator {
         window?.makeKeyAndVisible()
     }
 
-//    private func startSomeCoordinator() {
-//        guard let auth = auth else { return }
-//        auth.isSessionActive ? startMainTabCoordinator() : startLoginCoordinator()
-//        
-//    }
-//
-//    private func startLoginCoordinator() {
-//        let loginCoordinator = factory?.makeLogInCoordinator(
-//            navigation: navigation,
-//            delegate: self)
-//        addChildCoordinatorStart(loginCoordinator)
-//    }
-
     private func startMainTabCoordinator() {
         let mainTabCoordinator = factory?.makeMainTabCoordinator(
             navigation: navigation,
@@ -59,13 +46,6 @@ final class AppCoordinator: Coordinator {
         navigation.viewControllers = []
         clearAllChildsCoordinator()
         startMainTabCoordinator()
-    }
-}
-
-// MARK: - LogInCoordinatorDelegate
-extension AppCoordinator: LogInCoordinatorDelegate {
-    func didFinishLogin() {
-        clearCoordinatorsAndStart()
     }
 }
 

--- a/ATeen/ATeen/Composition/Coordinator/Navigation/Navigation.swift
+++ b/ATeen/ATeen/Composition/Coordinator/Navigation/Navigation.swift
@@ -16,9 +16,9 @@ protocol Navigation {
         animated: Bool,
         completion: (() -> Void)?)
     func pushViewController(
-    _ viewControllerToPresent: UIViewController,
-    animated: Bool,
-    backCompletion: (() -> Void)?
+        _ viewControllerToPresent: UIViewController,
+        animated: Bool,
+        backCompletion: (() -> Void)?
     )
     func dismiss(animated: Bool)
     func popViewController(animated: Bool)

--- a/ATeen/ATeen/Scenes/Login/LogIn/Composition/LogInCoordinator+LogInViewControllerCoordinator.swift
+++ b/ATeen/ATeen/Scenes/Login/LogIn/Composition/LogInCoordinator+LogInViewControllerCoordinator.swift
@@ -7,7 +7,7 @@
 
 extension LogInCoordinator: LogInViewControllerCoordinator {
     func didFinish() {
-        delegate?.didFinishLogin()
+        delegate?.didFinishLogin(childCoordinator: self)
     }
     
     func didSelectSignUpButton() {

--- a/ATeen/ATeen/Scenes/Login/LogIn/Composition/LogInCoordinator+PhoneNumberCoordinatorDelegate.swift
+++ b/ATeen/ATeen/Scenes/Login/LogIn/Composition/LogInCoordinator+PhoneNumberCoordinatorDelegate.swift
@@ -11,4 +11,9 @@ extension LogInCoordinator: PhoneNumberCoordinatorDelegate {
         removeChildCoordinator(childCoordinator)
         navigation.popViewController(animated: true)
     }
+    
+    func navigateToMainViewController() {
+        // login coordinator 지우기
+        delegate?.didFinishLogin(childCoordinator: self)
+    }
 }

--- a/ATeen/ATeen/Scenes/Login/LogIn/Composition/LogInCoordinator.swift
+++ b/ATeen/ATeen/Scenes/Login/LogIn/Composition/LogInCoordinator.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 protocol LogInCoordinatorDelegate: AnyObject {
-    func didFinishLogin()
+    func didFinishLogin(childCoordinator: Coordinator)
 }
 
 final class LogInCoordinator: Coordinator {

--- a/ATeen/ATeen/Scenes/Login/LogIn/Presentation/View/LogInViewController.swift
+++ b/ATeen/ATeen/Scenes/Login/LogIn/Presentation/View/LogInViewController.swift
@@ -187,7 +187,8 @@ final class LogInViewController: UIViewController {
     private func configAction() {
         let loginAction = UIAction { [weak self] _ in
             self?.viewModel.login()
-            self?.coordinator?.didFinish()
+            print("로그인")
+//            self?.coordinator?.didFinish()
         }
         loginButton.addAction(loginAction, for: .touchUpInside)
     }

--- a/ATeen/ATeen/Scenes/Login/PhoneNumber/Composition/ExistingUserLoginDialogCoordinator+ExistingUserLoginDialogViewControllerCoordinator.swift
+++ b/ATeen/ATeen/Scenes/Login/PhoneNumber/Composition/ExistingUserLoginDialogCoordinator+ExistingUserLoginDialogViewControllerCoordinator.swift
@@ -8,5 +8,7 @@
 import Foundation
 
 extension ExistingUserLoginDialogCoordinator: ExistingUserLoginDialogViewControllerCoordinator {
-    //
+    func navigateToMainViewController() {
+        delegate?.navigateToMainViewController(childCoordinator: self)
+    }
 }

--- a/ATeen/ATeen/Scenes/Login/PhoneNumber/Composition/ExistingUserLoginDialogCoordinator+ExistingUserLoginDialogViewControllerCoordinator.swift
+++ b/ATeen/ATeen/Scenes/Login/PhoneNumber/Composition/ExistingUserLoginDialogCoordinator+ExistingUserLoginDialogViewControllerCoordinator.swift
@@ -1,0 +1,12 @@
+//
+//  ExistingUserLoginDialogCoordinator+ExistingUserLoginDialogViewControllerCoordinator.swift
+//  ATeen
+//
+//  Created by phang on 6/8/24.
+//
+
+import Foundation
+
+extension ExistingUserLoginDialogCoordinator: ExistingUserLoginDialogViewControllerCoordinator {
+    //
+}

--- a/ATeen/ATeen/Scenes/Login/PhoneNumber/Composition/ExistingUserLoginDialogCoordinator.swift
+++ b/ATeen/ATeen/Scenes/Login/PhoneNumber/Composition/ExistingUserLoginDialogCoordinator.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 protocol ExistingUserLoginDialogCoordinatorDelegate: AnyObject {
-    //
+    func navigateToMainViewController(childCoordinator: Coordinator)
 }
 
 final class ExistingUserLoginDialogCoordinator: Coordinator {

--- a/ATeen/ATeen/Scenes/Login/PhoneNumber/Composition/ExistingUserLoginDialogCoordinator.swift
+++ b/ATeen/ATeen/Scenes/Login/PhoneNumber/Composition/ExistingUserLoginDialogCoordinator.swift
@@ -1,0 +1,35 @@
+//
+//  ExistingUserLoginDialogCoordinator.swift
+//  ATeen
+//
+//  Created by phang on 6/8/24.
+//
+
+import UIKit
+
+protocol ExistingUserLoginDialogCoordinatorDelegate: AnyObject {
+    //
+}
+
+final class ExistingUserLoginDialogCoordinator: Coordinator {
+    var navigation: Navigation
+    let factory: ExistingUserLoginDialogFactory
+    weak var delegate: ExistingUserLoginDialogCoordinatorDelegate?
+
+    init(
+        navigation: Navigation,
+        factory: ExistingUserLoginDialogFactory,
+        delegate: ExistingUserLoginDialogCoordinatorDelegate
+    ) {
+        self.navigation = navigation
+        self.factory = factory
+        self.delegate = delegate
+    }
+    
+    func start() {
+        let controller = factory.makeExistingUserLoginDialogViewController(
+            coordinator: self
+        )
+        navigation.present(controller, animated: false)
+    }
+}

--- a/ATeen/ATeen/Scenes/Login/PhoneNumber/Composition/ExistingUserLoginDialogFactory.swift
+++ b/ATeen/ATeen/Scenes/Login/PhoneNumber/Composition/ExistingUserLoginDialogFactory.swift
@@ -1,0 +1,24 @@
+//
+//  ExistingUserLoginDialogFactory.swift
+//  ATeen
+//
+//  Created by phang on 6/8/24.
+//
+
+import UIKit
+
+protocol ExistingUserLoginDialogFactory {
+    func makeExistingUserLoginDialogViewController(
+        coordinator: ExistingUserLoginDialogViewControllerCoordinator
+    ) -> UIViewController
+}
+
+struct ExistingUserLoginDialogFactoryImp: ExistingUserLoginDialogFactory {
+    func makeExistingUserLoginDialogViewController(
+        coordinator: ExistingUserLoginDialogViewControllerCoordinator
+    ) -> UIViewController {
+        let controller = ExistingUserLoginDialogViewController(coordinator: coordinator)
+        controller.modalPresentationStyle = .overFullScreen
+        return controller
+    }
+}

--- a/ATeen/ATeen/Scenes/Login/PhoneNumber/Composition/PhoneNumberCoordinator+ExistingUserLoginDialogCoordinatorDelegate.swift
+++ b/ATeen/ATeen/Scenes/Login/PhoneNumber/Composition/PhoneNumberCoordinator+ExistingUserLoginDialogCoordinatorDelegate.swift
@@ -1,0 +1,33 @@
+//
+//  PhoneNumberCoordinator+ExistingUserLoginDialogCoordinatorDelegate.swift
+//  ATeen
+//
+//  Created by phang on 6/9/24.
+//
+
+extension PhoneNumberCoordinator: ExistingUserLoginDialogCoordinatorDelegate {
+    func navigateToMainViewController(childCoordinator: Coordinator) {
+        // 다이얼로그 닫기
+        closeDialog(childCoordinator: childCoordinator)
+        // 인증 화면 -> 로그인 : 뒤로가기
+        navigateToLoginViewController()
+        // 로그인 시트 닫기
+        closeLoginSheet()
+    }
+    
+    private func closeDialog(childCoordinator: Coordinator) {
+        // 다이얼로그 닫기
+        childCoordinator.navigation.dismissNavigation = nil
+        removeChildCoordinator(childCoordinator)
+        navigation.dismiss(animated: false)
+    }
+    
+    private func navigateToLoginViewController() {
+        // 인증 화면 -> 로그인 : 뒤로가기
+        delegate?.didFinish(childCoordinator: self)
+    }
+    
+    private func closeLoginSheet() {
+        delegate?.navigateToMainViewController()
+    }
+}

--- a/ATeen/ATeen/Scenes/Login/PhoneNumber/Composition/PhoneNumberCoordinator+PhoneNumberViewControllerCoordinator.swift
+++ b/ATeen/ATeen/Scenes/Login/PhoneNumber/Composition/PhoneNumberCoordinator+PhoneNumberViewControllerCoordinator.swift
@@ -13,4 +13,18 @@ extension PhoneNumberCoordinator: PhoneNumberViewControllerCoordinator {
     func didSelectResendCode() {
         // TODO: 코드 재전송
     }
+    
+    func openVerificationCompleteDialog() {
+        let coordinator = factory.makeVerificationCompleteDialogCoordinator(
+            navigation: navigation,
+            delegate: self)
+        addChildCoordinatorStart(coordinator)
+    }
+    
+    func openExistingUserLoginDialog() {
+        let coordinator = factory.makeExistingUserLoginDialogCoordinator(
+            navigation: navigation,
+            delegate: self)
+        addChildCoordinatorStart(coordinator)
+    }
 }

--- a/ATeen/ATeen/Scenes/Login/PhoneNumber/Composition/PhoneNumberCoordinator+PhoneNumberViewControllerCoordinator.swift
+++ b/ATeen/ATeen/Scenes/Login/PhoneNumber/Composition/PhoneNumberCoordinator+PhoneNumberViewControllerCoordinator.swift
@@ -9,14 +9,6 @@ extension PhoneNumberCoordinator: PhoneNumberViewControllerCoordinator {
     func didFinish() {
         delegate?.didFinish(childCoordinator: self)
     }
-
-    func didSelectNextButton() {
-        let coordinator = factory.makeTermsOfUseCoordinator(
-            navigation: navigation,
-            childCoordinators: childCoordinators,
-            delegate: self)
-        addChildCoordinatorStart(coordinator)
-    }
     
     func didSelectResendCode() {
         // TODO: 코드 재전송

--- a/ATeen/ATeen/Scenes/Login/PhoneNumber/Composition/PhoneNumberCoordinator+VerificationCompleteDialogCoordinatorDelegate.swift
+++ b/ATeen/ATeen/Scenes/Login/PhoneNumber/Composition/PhoneNumberCoordinator+VerificationCompleteDialogCoordinatorDelegate.swift
@@ -5,23 +5,7 @@
 //  Created by phang on 6/8/24.
 //
 
-extension PhoneNumberCoordinator: VerificationCompleteDialogCoordinatorDelegate,
-                                  ExistingUserLoginDialogCoordinatorDelegate {
-    func didSelectNextButton(registrationStatus: RegistrationStatus) {
-        if registrationStatus == .notSignedUp {
-            let coordinator = factory.makeVerificationCompleteDialogCoordinator(
-                navigation: navigation,
-                delegate: self)
-            addChildCoordinatorStart(coordinator)
-        } else {
-            let coordinator = factory.makeExistingUserLoginDialogCoordinator(
-                navigation: navigation,
-                delegate: self)
-            addChildCoordinatorStart(coordinator)
-        }
-    }
-    
-    func didSelectOKButton(childCoordinator: Coordinator) {
+extension PhoneNumberCoordinator: VerificationCompleteDialogCoordinatorDelegate {    func didSelectOKButton(childCoordinator: Coordinator) {
         // 현재 Dialog 닫기
         childCoordinator.navigation.dismissNavigation = nil
         removeChildCoordinator(childCoordinator)

--- a/ATeen/ATeen/Scenes/Login/PhoneNumber/Composition/PhoneNumberCoordinator+VerificationCompleteDialogCoordinatorDelegate.swift
+++ b/ATeen/ATeen/Scenes/Login/PhoneNumber/Composition/PhoneNumberCoordinator+VerificationCompleteDialogCoordinatorDelegate.swift
@@ -1,0 +1,36 @@
+//
+//  PhoneNumberCoordinator+VerificationCompleteDialogCoordinatorDelegate.swift
+//  ATeen
+//
+//  Created by phang on 6/8/24.
+//
+
+extension PhoneNumberCoordinator: VerificationCompleteDialogCoordinatorDelegate,
+                                  ExistingUserLoginDialogCoordinatorDelegate {
+    func didSelectNextButton(registrationStatus: RegistrationStatus) {
+        if registrationStatus == .notSignedUp {
+            let coordinator = factory.makeVerificationCompleteDialogCoordinator(
+                navigation: navigation,
+                delegate: self)
+            addChildCoordinatorStart(coordinator)
+        } else {
+            let coordinator = factory.makeExistingUserLoginDialogCoordinator(
+                navigation: navigation,
+                delegate: self)
+            addChildCoordinatorStart(coordinator)
+        }
+    }
+    
+    func didSelectOKButton(childCoordinator: Coordinator) {
+        // 현재 Dialog 닫기
+        childCoordinator.navigation.dismissNavigation = nil
+        removeChildCoordinator(childCoordinator)
+        navigation.dismiss(animated: false)
+        // 이후 화면 이동
+        let coordinator = factory.makeTermsOfUseCoordinator(
+            navigation: navigation,
+            childCoordinators: childCoordinators,
+            delegate: self)
+        addChildCoordinatorStart(coordinator)
+    }
+}

--- a/ATeen/ATeen/Scenes/Login/PhoneNumber/Composition/PhoneNumberCoordinator.swift
+++ b/ATeen/ATeen/Scenes/Login/PhoneNumber/Composition/PhoneNumberCoordinator.swift
@@ -9,6 +9,7 @@ import Foundation
 
 protocol PhoneNumberCoordinatorDelegate: AnyObject {
     func didFinish(childCoordinator: Coordinator)
+    func navigateToMainViewController()
 }
 
 final class PhoneNumberCoordinator: Coordinator {
@@ -17,10 +18,11 @@ final class PhoneNumberCoordinator: Coordinator {
     var childCoordinators: [Coordinator]
     weak var delegate: PhoneNumberCoordinatorDelegate?
     
-    init(navigation: Navigation,
-         factory: PhoneNumberFactory,
-         childCoordinators: [Coordinator],
-         delegate: PhoneNumberCoordinatorDelegate
+    init(
+        navigation: Navigation,
+        factory: PhoneNumberFactory,
+        childCoordinators: [Coordinator],
+        delegate: PhoneNumberCoordinatorDelegate
     ) {
         self.navigation = navigation
         self.factory = factory

--- a/ATeen/ATeen/Scenes/Login/PhoneNumber/Composition/PhoneNumberFactory.swift
+++ b/ATeen/ATeen/Scenes/Login/PhoneNumber/Composition/PhoneNumberFactory.swift
@@ -14,6 +14,14 @@ protocol PhoneNumberFactory {
         childCoordinators: [Coordinator],
         delegate: TermsOfUseCoordinatorDelegate
     ) -> Coordinator
+    func makeVerificationCompleteDialogCoordinator(
+        navigation: Navigation,
+        delegate: VerificationCompleteDialogCoordinatorDelegate
+    ) -> Coordinator
+    func makeExistingUserLoginDialogCoordinator(
+        navigation: Navigation,
+        delegate: ExistingUserLoginDialogCoordinatorDelegate
+    ) -> Coordinator
 }
 
 struct PhoneNumberFactoryImp: PhoneNumberFactory {
@@ -32,6 +40,28 @@ struct PhoneNumberFactoryImp: PhoneNumberFactory {
             navigation: navigation,
             factory: factory,
             childCoordinators: childCoordinators,
+            delegate: delegate)
+    }
+    
+    func makeVerificationCompleteDialogCoordinator(
+        navigation: Navigation,
+        delegate: VerificationCompleteDialogCoordinatorDelegate
+    ) -> Coordinator {
+        let factory = VerificationCompleteDialogFactoryImp()
+        return VerificationCompleteDialogCoordinator(
+            navigation: navigation,
+            factory: factory,
+            delegate: delegate)
+    }
+    
+    func makeExistingUserLoginDialogCoordinator(
+        navigation: Navigation,
+        delegate: ExistingUserLoginDialogCoordinatorDelegate
+    ) -> Coordinator {
+        let factory = ExistingUserLoginDialogFactoryImp()
+        return ExistingUserLoginDialogCoordinator(
+            navigation: navigation,
+            factory: factory,
             delegate: delegate)
     }
 }

--- a/ATeen/ATeen/Scenes/Login/PhoneNumber/Composition/VerificationCompleteDialogCoordinator+VerificationCompleteDialogViewControllerCoordinator.swift
+++ b/ATeen/ATeen/Scenes/Login/PhoneNumber/Composition/VerificationCompleteDialogCoordinator+VerificationCompleteDialogViewControllerCoordinator.swift
@@ -1,0 +1,14 @@
+//
+//  VerificationCompleteDialogCoordinator+VerificationCompleteDialogViewControllerCoordinator.swift
+//  ATeen
+//
+//  Created by phang on 6/8/24.
+//
+
+import Foundation
+
+extension VerificationCompleteDialogCoordinator: VerificationCompleteDialogViewControllerCoordinator {
+    func didSelectOKButton() {
+        delegate?.didSelectOKButton(childCoordinator: self)
+    }
+}

--- a/ATeen/ATeen/Scenes/Login/PhoneNumber/Composition/VerificationCompleteDialogCoordinator.swift
+++ b/ATeen/ATeen/Scenes/Login/PhoneNumber/Composition/VerificationCompleteDialogCoordinator.swift
@@ -1,0 +1,35 @@
+//
+//  VerificationCompleteDialogCoordinator.swift
+//  ATeen
+//
+//  Created by phang on 6/8/24.
+//
+
+import UIKit
+
+protocol VerificationCompleteDialogCoordinatorDelegate: AnyObject {
+    func didSelectOKButton(childCoordinator: Coordinator)
+}
+
+final class VerificationCompleteDialogCoordinator: Coordinator {
+    var navigation: Navigation
+    let factory: VerificationCompleteDialogFactory
+    weak var delegate: VerificationCompleteDialogCoordinatorDelegate?
+
+    init(
+        navigation: Navigation,
+        factory: VerificationCompleteDialogFactory,
+        delegate: VerificationCompleteDialogCoordinatorDelegate
+    ) {
+        self.navigation = navigation
+        self.factory = factory
+        self.delegate = delegate
+    }
+    
+    func start() {
+        let controller = factory.makeVerificationCompleteDialogViewController(
+            coordinator: self
+        )
+        navigation.present(controller, animated: false)
+    }
+}

--- a/ATeen/ATeen/Scenes/Login/PhoneNumber/Composition/VerificationCompleteDialogFactory.swift
+++ b/ATeen/ATeen/Scenes/Login/PhoneNumber/Composition/VerificationCompleteDialogFactory.swift
@@ -1,0 +1,24 @@
+//
+//  VerificationCompleteDialogFactory.swift
+//  ATeen
+//
+//  Created by phang on 6/8/24.
+//
+
+import UIKit
+
+protocol VerificationCompleteDialogFactory {
+    func makeVerificationCompleteDialogViewController(
+        coordinator: VerificationCompleteDialogViewControllerCoordinator
+    ) -> UIViewController
+}
+
+struct VerificationCompleteDialogFactoryImp: VerificationCompleteDialogFactory {
+    func makeVerificationCompleteDialogViewController(
+        coordinator: VerificationCompleteDialogViewControllerCoordinator
+    ) -> UIViewController {
+        let controller = VerificationCompleteDialogViewController(coordinator: coordinator)
+        controller.modalPresentationStyle = .overFullScreen
+        return controller
+    }
+}

--- a/ATeen/ATeen/Scenes/Login/PhoneNumber/Presentation/Cell/CertificationCodeCollectionViewCell.swift
+++ b/ATeen/ATeen/Scenes/Login/PhoneNumber/Presentation/Cell/CertificationCodeCollectionViewCell.swift
@@ -172,9 +172,11 @@ final class CertificationCodeCollectionViewCell: UICollectionViewCell {
         // TODO: - 다음으로 이동할때, 가입된 사용자인지 검증 후 보내주기
         let isNotSignedUpUser = true
         if isNotSignedUpUser {      // 가입 가능
-            delegate?.didSelectNextButton(registrationStatus: .signedUp)
-        } else {                    // 이미 가입된 사용자
+            print("가입 가능")
             delegate?.didSelectNextButton(registrationStatus: .notSignedUp)
+        } else {                    // 이미 가입된 사용자
+            print("이미 가입된 사용자")
+            delegate?.didSelectNextButton(registrationStatus: .signedUp)
         }
     }
     

--- a/ATeen/ATeen/Scenes/Login/PhoneNumber/Presentation/Cell/CertificationCodeCollectionViewCell.swift
+++ b/ATeen/ATeen/Scenes/Login/PhoneNumber/Presentation/Cell/CertificationCodeCollectionViewCell.swift
@@ -9,8 +9,13 @@ import SnapKit
 
 import UIKit
 
+enum RegistrationStatus {
+    case signedUp
+    case notSignedUp
+}
+
 protocol CertificationCodeCollectionViewCellDelegate: AnyObject {
-    func didSelectNextButton()
+    func didSelectNextButton(registrationStatus: RegistrationStatus)
     func didSelectResendCode()
 }
 
@@ -164,7 +169,13 @@ final class CertificationCodeCollectionViewCell: UICollectionViewCell {
     
     // MARK: - Actions
     @objc private func didSelectNextButton(_ sender: UIButton) {
-        delegate?.didSelectNextButton()
+        // TODO: - 다음으로 이동할때, 가입된 사용자인지 검증 후 보내주기
+        let isNotSignedUpUser = true
+        if isNotSignedUpUser {      // 가입 가능
+            delegate?.didSelectNextButton(registrationStatus: .signedUp)
+        } else {                    // 이미 가입된 사용자
+            delegate?.didSelectNextButton(registrationStatus: .notSignedUp)
+        }
     }
     
     @objc private func didSelectResendButton(_ sender: UIButton) {

--- a/ATeen/ATeen/Scenes/Login/PhoneNumber/Presentation/View/ExistingUserLoginDialogViewController.swift
+++ b/ATeen/ATeen/Scenes/Login/PhoneNumber/Presentation/View/ExistingUserLoginDialogViewController.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 protocol ExistingUserLoginDialogViewControllerCoordinator: AnyObject {
-    // TODO: - 로그인 + 메인 이동 or 로그인 X + 메인 이동
+    func navigateToMainViewController()
 }
 
 final class ExistingUserLoginDialogViewController: CustomTwoButtonDialogViewController {
@@ -50,13 +50,15 @@ final class ExistingUserLoginDialogViewController: CustomTwoButtonDialogViewCont
     // MARK: - Actions
     override func clickLeftButton(_ sender: UIButton) {
         super.clickLeftButton(sender)
-        //
-        print("왼쪽 버튼 클릭")
+        // TODO: 로그인 안된 상태로 메인화면 이동
+        print("로그인 X")
+        coordinator?.navigateToMainViewController()
     }
     
     override func clickRightButton(_ sender: UIButton) {
         super.clickRightButton(sender)
-        //
-        print("오른쪽 버튼 클릭")
+        // TODO: 로그인 상태로 메인화면 이동
+        print("로그인 O")
+        coordinator?.navigateToMainViewController()
     }
 }

--- a/ATeen/ATeen/Scenes/Login/PhoneNumber/Presentation/View/ExistingUserLoginDialogViewController.swift
+++ b/ATeen/ATeen/Scenes/Login/PhoneNumber/Presentation/View/ExistingUserLoginDialogViewController.swift
@@ -1,0 +1,62 @@
+//
+//  ExistingUserLoginDialogViewController.swift
+//  ATeen
+//
+//  Created by phang on 6/7/24.
+//
+
+import UIKit
+
+protocol ExistingUserLoginDialogViewControllerCoordinator: AnyObject {
+    // TODO: - 로그인 + 메인 이동 or 로그인 X + 메인 이동
+}
+
+final class ExistingUserLoginDialogViewController: CustomTwoButtonDialogViewController {
+    private var coordinator: ExistingUserLoginDialogViewControllerCoordinator?
+    
+    init(
+        coordinator: ExistingUserLoginDialogViewControllerCoordinator,
+        dialogImage: UIImage? = nil,
+        dialogTitle: String? = "이미 가입된 사용자에요!",
+        titleColor: UIColor = .black,
+        titleNumberOfLine: Int = 1,
+        titleFont: UIFont = .customFont(forTextStyle: .callout, weight: .bold),
+        dialogMessage: String = "바로 로그인 할까요?",
+        messageColor: UIColor = .gray02,
+        messageNumberOfLine: Int = 1,
+        messageFont: UIFont = .customFont(forTextStyle: .footnote, weight: .regular),
+        leftButtonText: String = "아니요",
+        leftButtonColor: UIColor = .gray01,
+        rightButtonText: String = "좋아요!",
+        rightButtonColor: UIColor = .main
+    ) {
+        self.coordinator = coordinator
+        super.init(
+            dialogTitle: dialogTitle,
+            titleNumberOfLine: titleNumberOfLine,
+            dialogMessage: dialogMessage,
+            messageNumberOfLine: messageNumberOfLine,
+            leftButtonText: leftButtonText,
+            leftButtonColor: leftButtonColor,
+            rightButtonText: rightButtonText,
+            rightButtonColor: rightButtonColor
+        )
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Actions
+    override func clickLeftButton(_ sender: UIButton) {
+        super.clickLeftButton(sender)
+        //
+        print("왼쪽 버튼 클릭")
+    }
+    
+    override func clickRightButton(_ sender: UIButton) {
+        super.clickRightButton(sender)
+        //
+        print("오른쪽 버튼 클릭")
+    }
+}

--- a/ATeen/ATeen/Scenes/Login/PhoneNumber/Presentation/View/ExistingUserLoginDialogViewController.swift
+++ b/ATeen/ATeen/Scenes/Login/PhoneNumber/Presentation/View/ExistingUserLoginDialogViewController.swift
@@ -17,17 +17,17 @@ final class ExistingUserLoginDialogViewController: CustomTwoButtonDialogViewCont
     init(
         coordinator: ExistingUserLoginDialogViewControllerCoordinator,
         dialogImage: UIImage? = nil,
-        dialogTitle: String? = "이미 가입된 사용자에요!",
+        dialogTitle: String? = AppLocalized.existingUserDialogTitle,
         titleColor: UIColor = .black,
         titleNumberOfLine: Int = 1,
         titleFont: UIFont = .customFont(forTextStyle: .callout, weight: .bold),
-        dialogMessage: String = "바로 로그인 할까요?",
+        dialogMessage: String = AppLocalized.existingUserDialogMessage,
         messageColor: UIColor = .gray02,
         messageNumberOfLine: Int = 1,
         messageFont: UIFont = .customFont(forTextStyle: .footnote, weight: .regular),
-        leftButtonText: String = "아니요",
+        leftButtonText: String = AppLocalized.noButton,
         leftButtonColor: UIColor = .gray01,
-        rightButtonText: String = "좋아요!",
+        rightButtonText: String = AppLocalized.okGoodButton,
         rightButtonColor: UIColor = .main
     ) {
         self.coordinator = coordinator

--- a/ATeen/ATeen/Scenes/Login/PhoneNumber/Presentation/View/PhoneNumberViewController.swift
+++ b/ATeen/ATeen/Scenes/Login/PhoneNumber/Presentation/View/PhoneNumberViewController.swift
@@ -11,7 +11,7 @@ import UIKit
 
 protocol PhoneNumberViewControllerCoordinator: AnyObject {
     func didFinish()
-    func didSelectNextButton()
+    func didSelectNextButton(registrationStatus: RegistrationStatus)
     func didSelectResendCode()
 }
 
@@ -154,8 +154,8 @@ extension PhoneNumberViewController: PhoneNumberCollectionViewCellDelegate {
 }
 
 extension PhoneNumberViewController: CertificationCodeCollectionViewCellDelegate {
-    func didSelectNextButton() {
-        coordinator?.didSelectNextButton()
+    func didSelectNextButton(registrationStatus: RegistrationStatus) {
+        coordinator?.didSelectNextButton(registrationStatus: registrationStatus)
     }
     
     func didSelectResendCode() {

--- a/ATeen/ATeen/Scenes/Login/PhoneNumber/Presentation/View/PhoneNumberViewController.swift
+++ b/ATeen/ATeen/Scenes/Login/PhoneNumber/Presentation/View/PhoneNumberViewController.swift
@@ -11,7 +11,8 @@ import UIKit
 
 protocol PhoneNumberViewControllerCoordinator: AnyObject {
     func didFinish()
-    func didSelectNextButton(registrationStatus: RegistrationStatus)
+    func openVerificationCompleteDialog()
+    func openExistingUserLoginDialog()
     func didSelectResendCode()
 }
 
@@ -155,7 +156,11 @@ extension PhoneNumberViewController: PhoneNumberCollectionViewCellDelegate {
 
 extension PhoneNumberViewController: CertificationCodeCollectionViewCellDelegate {
     func didSelectNextButton(registrationStatus: RegistrationStatus) {
-        coordinator?.didSelectNextButton(registrationStatus: registrationStatus)
+        if registrationStatus == .notSignedUp {
+            coordinator?.openVerificationCompleteDialog()
+        } else {
+            coordinator?.openExistingUserLoginDialog()
+        }
     }
     
     func didSelectResendCode() {

--- a/ATeen/ATeen/Scenes/Login/PhoneNumber/Presentation/View/VerificationCompleteDialogViewController.swift
+++ b/ATeen/ATeen/Scenes/Login/PhoneNumber/Presentation/View/VerificationCompleteDialogViewController.swift
@@ -16,18 +16,15 @@ final class VerificationCompleteDialogViewController: CustomConfirmDialogViewCon
     
     init(
         coordinator: VerificationCompleteDialogViewControllerCoordinator,
-        dialogTitle: String? = "인증이 완료되었어요!",
+        dialogTitle: String? = AppLocalized.verificationCompleteDialogTitle,
         titleColor: UIColor = .black,
         titleNumberOfLine: Int = 1,
         titleFont: UIFont = .customFont(forTextStyle: .callout, weight: .bold),
-        dialogMessage: String = """
-                                A-TEEN에 정보를 입력하여
-                                가입을 마저 완료해보세요.
-                                """,
+        dialogMessage: String = AppLocalized.verificationCompleteDialogMessage,
         messageColor: UIColor = .gray02,
         messageNumberOfLine: Int = 2,
         messageFont: UIFont = .customFont(forTextStyle: .footnote, weight: .regular),
-        buttonText: String = "좋아요!",
+        buttonText: String = AppLocalized.okGoodButton,
         buttonColor: UIColor = .black
     ) {
         self.coordinator = coordinator

--- a/ATeen/ATeen/Scenes/Login/PhoneNumber/Presentation/View/VerificationCompleteDialogViewController.swift
+++ b/ATeen/ATeen/Scenes/Login/PhoneNumber/Presentation/View/VerificationCompleteDialogViewController.swift
@@ -1,0 +1,52 @@
+//
+//  VerificationCompleteDialogViewController.swift
+//  ATeen
+//
+//  Created by phang on 6/7/24.
+//
+
+import UIKit
+
+protocol VerificationCompleteDialogViewControllerCoordinator: AnyObject {
+    func didSelectOKButton()
+}
+
+final class VerificationCompleteDialogViewController: CustomConfirmDialogViewController {
+    private weak var coordinator: VerificationCompleteDialogViewControllerCoordinator?
+    
+    init(
+        coordinator: VerificationCompleteDialogViewControllerCoordinator,
+        dialogTitle: String? = "인증이 완료되었어요!",
+        titleColor: UIColor = .black,
+        titleNumberOfLine: Int = 1,
+        titleFont: UIFont = .customFont(forTextStyle: .callout, weight: .bold),
+        dialogMessage: String = """
+                                A-TEEN에 정보를 입력하여
+                                가입을 마저 완료해보세요.
+                                """,
+        messageColor: UIColor = .gray02,
+        messageNumberOfLine: Int = 2,
+        messageFont: UIFont = .customFont(forTextStyle: .footnote, weight: .regular),
+        buttonText: String = "좋아요!",
+        buttonColor: UIColor = .black
+    ) {
+        self.coordinator = coordinator
+        super.init(
+            dialogTitle: dialogTitle,
+            dialogMessage: dialogMessage,
+            messageNumberOfLine: messageNumberOfLine,
+            buttonText: buttonText,
+            buttonColor: buttonColor
+        )
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Actions
+    override func clickConfirmButton(_ sender: UIButton) {
+        super.clickConfirmButton(sender)
+        coordinator?.didSelectOKButton()
+    }
+}

--- a/ATeen/ATeen/Scenes/Login/SignUp/Composition/SignUpFactory.swift
+++ b/ATeen/ATeen/Scenes/Login/SignUp/Composition/SignUpFactory.swift
@@ -49,7 +49,6 @@ struct SignUpFactoryImp: SignUpFactory {
             delegate: delegate)
     }
     
-    
     func makeSelectBirthCoordinator(
         delegate: ProfileDetailCoordinatorDelegate,
         frame: CGRect,

--- a/ATeen/ATeen/Scenes/Main/Components/Button/CustomUsedToReportViewButton.swift
+++ b/ATeen/ATeen/Scenes/Main/Components/Button/CustomUsedToReportViewButton.swift
@@ -47,11 +47,11 @@ extension CustomUsedToReportViewButton {
         customImageView.snp.makeConstraints { make in
             make.leading.equalToSuperview()
             make.centerY.equalToSuperview()
-            make.width.height.equalTo(22)
+            make.width.height.equalTo(20)
         }
         
         customLabel.snp.makeConstraints { make in
-            make.leading.equalTo(customImageView.snp.trailing).offset(8)
+            make.leading.equalTo(customImageView.snp.trailing).offset(10)
             make.centerY.equalTo(customImageView.snp.centerY)
         }
     }

--- a/ATeen/ATeen/Scenes/Main/Presentation/View/ReportCompleteDialogViewController.swift
+++ b/ATeen/ATeen/Scenes/Main/Presentation/View/ReportCompleteDialogViewController.swift
@@ -17,18 +17,18 @@ final class ReportCompleteDialogViewController: CustomConfirmDialogViewControlle
     // MARK: - Life Cycle
     init(
         coordinator: ReportCompleteDialogViewControllerCoordinator,
-        dialogTitle: String? = "신고가 완료되었습니다.",
+        dialogTitle: String? = AppLocalized.reportCompleteDialogTitle,
         titleColor: UIColor = .black,
         titleNumberOfLine: Int = 1,
         titleFont: UIFont = .customFont(forTextStyle: .callout, weight: .bold),
-        dialogMessage: String =  """
+        dialogMessage: String = """
                                 해당 프로필은 oo님에게
                                 더이상 표시되지 않아요
                                 """,
         messageColor: UIColor = .gray02,
         messageNumberOfLine: Int = 2,
         messageFont: UIFont = .customFont(forTextStyle: .footnote, weight: .regular),
-        buttonText: String = "알겠어요!",
+        buttonText: String = AppLocalized.okButton,
         buttonColor: UIColor = .main
     ) {
         self.coordinator = coordinator

--- a/ATeen/ATeen/Scenes/Main/Presentation/View/ReportDialogViewController.swift
+++ b/ATeen/ATeen/Scenes/Main/Presentation/View/ReportDialogViewController.swift
@@ -35,7 +35,7 @@ final class ReportDialogViewController: UIViewController {
     
     private lazy var titleLabel: UILabel = {
         let label = UILabel()
-        label.text = "신고사유"
+        label.text = AppLocalized.reportDialogTitle
         label.textColor = .black
         label.textAlignment = .center
         label.font = UIFont.customFont(forTextStyle: .callout,
@@ -48,7 +48,7 @@ final class ReportDialogViewController: UIViewController {
             imageName: "circleButton",
             selectedImageName: "clickedCircleButton",
             imageColor: .gray03,
-            labelText: "따돌림 또는 괴롭힘")
+            labelText: AppLocalized.reportDialogViolenceReason)
         button.tag = 1
         button.isSelected = false
         return button
@@ -59,7 +59,7 @@ final class ReportDialogViewController: UIViewController {
             imageName: "circleButton",
             selectedImageName: "clickedCircleButton",
             imageColor: .gray03,
-            labelText: "불법적인 게시물")
+            labelText: AppLocalized.reportDialogAdReason)
         button.tag = 2
         button.isSelected = false
         return button
@@ -70,7 +70,7 @@ final class ReportDialogViewController: UIViewController {
             imageName: "circleButton",
             selectedImageName: "clickedCircleButton",
             imageColor: .gray03,
-            labelText: "혐오 발언 또는 상징")
+            labelText: AppLocalized.reportDialogImpersonationReason)
         button.tag = 3
         button.isSelected = false
         return button
@@ -81,7 +81,7 @@ final class ReportDialogViewController: UIViewController {
             imageName: "circleButton",
             selectedImageName: "clickedCircleButton",
             imageColor: .gray03,
-            labelText: "기타")
+            labelText: AppLocalized.reportDialogETCReason)
         button.tag = 4
         button.isSelected = false
         return button
@@ -91,7 +91,7 @@ final class ReportDialogViewController: UIViewController {
         let textView = UITextView()
         textView.delegate = self
         textView.backgroundColor = .white
-        textView.text = "신고 사유를 작성해주세요."
+        textView.text = AppLocalized.reportDialogPlaceholderText
         textView.textColor = .gray01
         textView.autocapitalizationType = .none
         textView.autocorrectionType = .no
@@ -113,14 +113,14 @@ final class ReportDialogViewController: UIViewController {
             imageName: "grayCheckButton",
             selectedImageName: "mainCheckButton",
             imageColor: .gray03,
-            labelText: "해당 프로필 다시는 보지 않기")
+            labelText: AppLocalized.reportDialogBlockButtonText)
         button.isSelected = false
         return button
     }()
     
     private lazy var explainMessageLabel: UILabel = {
         let label = UILabel()
-        label.text = "신고는 반대 의견을 표시하는 기능이 아닙니다."
+        label.text = AppLocalized.reportDialogExplainText
         label.textColor = .gray01
         label.textAlignment = .center
         label.font = UIFont.customFont(forTextStyle: .footnote,
@@ -132,7 +132,7 @@ final class ReportDialogViewController: UIViewController {
         let button = UIButton()
         button.titleLabel?.font = UIFont.customFont(forTextStyle: .callout,
                                                     weight: .regular)
-        button.setTitle("신고하기", for: .normal)
+        button.setTitle(AppLocalized.reportButton, for: .normal)
         button.setTitleColor(.white, for: .normal)
         button.backgroundColor = .gray01
         button.layer.cornerRadius = ViewValues.defaultRadius
@@ -380,7 +380,7 @@ extension ReportDialogViewController: UITextViewDelegate {
     
     func textViewDidEndEditing(_ textView: UITextView) {
         if (textView.text == "") {
-            textView.text = "신고 사유를 작성해주세요."
+            textView.text = AppLocalized.reportDialogPlaceholderText
             textView.textColor = .gray01
         }
     }

--- a/ATeen/ATeen/Scenes/Main/Presentation/View/ReportDialogViewController.swift
+++ b/ATeen/ATeen/Scenes/Main/Presentation/View/ReportDialogViewController.swift
@@ -257,7 +257,7 @@ final class ReportDialogViewController: UIViewController {
         }
         
         explainMessageLabel.snp.makeConstraints { make in
-            make.top.equalTo(blockButton.snp.bottom).offset(8)
+            make.top.equalTo(blockButton.snp.bottom).offset(12)
             make.leading.equalToSuperview().offset(20)
         }
         

--- a/ATeen/ATeen/Scenes/Main/Presentation/View/ReportPopoverViewController.swift
+++ b/ATeen/ATeen/Scenes/Main/Presentation/View/ReportPopoverViewController.swift
@@ -31,13 +31,13 @@ final class ReportPopoverViewController: UIViewController {
     
     private lazy var reportButton: UIButton = {
         let button = CustomPopoverButton(imageName: "reportIcon",
-                                         labelText: "신고하기")
+                                         labelText: AppLocalized.reportButton)
         return button
     }()
     
     private lazy var blockButton: UIButton = {
         let button = CustomPopoverButton(imageName: "blockIcon",
-                                         labelText: "차단하기")
+                                         labelText: AppLocalized.blockButton)
         return button
     }()
     

--- a/ATeen/ATeen/Scenes/Main/Presentation/View/ReportPopoverViewController.swift
+++ b/ATeen/ATeen/Scenes/Main/Presentation/View/ReportPopoverViewController.swift
@@ -23,7 +23,7 @@ final class ReportPopoverViewController: UIViewController {
     private lazy var popoverView: UIView = {
         let view = UIView()
         view.backgroundColor = .white
-        view.layer.cornerRadius = 10
+        view.layer.cornerRadius = ViewValues.defaultRadius
         view.layer.borderWidth = 1.0
         view.layer.borderColor = UIColor.gray03.cgColor
         return view

--- a/ATeen/ATeen/Scenes/Main/Presentation/View/ReportPopoverViewController.swift
+++ b/ATeen/ATeen/Scenes/Main/Presentation/View/ReportPopoverViewController.swift
@@ -24,6 +24,8 @@ final class ReportPopoverViewController: UIViewController {
         let view = UIView()
         view.backgroundColor = .white
         view.layer.cornerRadius = 10
+        view.layer.borderWidth = 1.0
+        view.layer.borderColor = UIColor.gray03.cgColor
         return view
     }()
     

--- a/ATeen/ATeen/Scenes/MainTab/Composition/MainTabCoordinator+LogInCoordinatorDelegate.swift
+++ b/ATeen/ATeen/Scenes/MainTab/Composition/MainTabCoordinator+LogInCoordinatorDelegate.swift
@@ -8,7 +8,13 @@
 import UIKit
 
 extension MainTabCoordinator: LogInCoordinatorDelegate {
-    func didFinishLogin() {
-        print("하이")
+    func didFinishLogin(childCoordinator: Coordinator) {
+        //
+        childCoordinator.navigation.dismissNavigation = nil
+        removeChildCoordinator(childCoordinator)
+        navigation.dismiss(animated: true)
+        //
+        clearAllChildsCoordinator()
+        delegate?.didFinish()
     }
 }


### PR DESCRIPTION
## MainView & LoginView : 다이얼로그, 팝오버 - 디자인 수정 & 화면 연결

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 버그 수정
- [x] 사용자 UI 디자인 변경
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [x] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 🔎 작업 내용
- [💄 Design: popover 에 border 추가](https://github.com/LayTheGroundWork/A-Teen_iOS/commit/d959f2048ed17a8b69d5c2035042c2fd821eab2d)
- [🎨 Style: ReportDialogViewController 의 신고 사유 수정](https://github.com/LayTheGroundWork/A-Teen_iOS/commit/d13d8615e9f7ce6e97f00db8b3d6d7125ba804d9)
( * MainViewController 에서 띄우는 Report 관련 Sring 원시값 AppLocalized 처리 )
- [💄 Design: 버튼 두개 있는 다이얼로그 컴포넌트 작성](https://github.com/LayTheGroundWork/A-Teen_iOS/commit/181b62efa69fdb73f80d2be05475520bdd8e12cb)
- [🐞 Fix: 다이얼로그의 Title 이 없는 경우를 고려해서 레이아웃 수정](https://github.com/LayTheGroundWork/A-Teen_iOS/commit/58277c10d6a7bb711c9ffecaff1cdee12166a11d)
( * CustomConfirmDialogViewController )
- [🏫 Feat: 로그인 시트 - 인증번호 다음 다이얼로그 화면 추가 및 연결](https://github.com/LayTheGroundWork/A-Teen_iOS/commit/4468d07685f61363680acce8b117243ca4e6ea0b)
- [🐞 Fix: 다이얼로그의 Title 이 없는 경우를 고려해서 레이아웃 수정](https://github.com/LayTheGroundWork/A-Teen_iOS/commit/d70f8be2ba59c252fc8853d00c0369c07d0e9801)
( * CustomTwoButtonDialogViewController )
- [🎨 Style: AppLocalized 적용 및 오타 수정](https://github.com/LayTheGroundWork/A-Teen_iOS/commit/11a3f58664f1a625f501c54e61d8951f2c265814)
( * ExistingUserLoginDialogViewController, 
VerificationCompleteDialogViewController, 
ReportCompleteDialogViewController )
- [💄 Design: 신고 사유 등록 다이얼로그 디자인 변경에 따른 수정](https://github.com/LayTheGroundWork/A-Teen_iOS/commit/4d7d5e7e9ea4aafad0c3abb3b64040fd57b383a3)
- [💄 Design: 신고 popover radius 수정](https://github.com/LayTheGroundWork/A-Teen_iOS/commit/d6fb91ae181b4aaca0487b23b7f9d56c0e826fab)
- [🏫 Feat: 인증번호 확인 이후, 다이얼로그에서 화면 이동](https://github.com/LayTheGroundWork/A-Teen_iOS/commit/849202e3b496b33a06b7d9c46e5ebca23000d746)

  <br/>

## 이미지 첨부

### 신고하기 popover 디자인 수정 
( * 왼쪽 : 변경 전 / 오른쪽 : 변경 후 )
<img width="300" alt="변경 전" src="https://github.com/LayTheGroundWork/A-Teen_iOS/assets/109324421/340671bd-332e-4701-ba6f-630aba34de42"><img width="300" alt="변경 후" src="https://github.com/LayTheGroundWork/A-Teen_iOS/assets/109324421/f31bf380-9660-41af-8ef7-37850717a5a8">
<br>


### 신고 사유 Dialog 디자인 수정 ( 버튼 크기 및 패딩 )
( * 왼쪽 : 변경 전 / 오른쪽 : 변경 후 )
<img width="300" alt="변경 전" src="https://github.com/LayTheGroundWork/A-Teen_iOS/assets/109324421/0dfde82d-ba02-4317-b061-8f05cdf1bc1c"><img width="300" alt="변경 후" src="https://github.com/LayTheGroundWork/A-Teen_iOS/assets/109324421/475e7824-1de9-44b9-bfa6-da742da08716">
<br>


### 가입 가능 시, `VerificationCompleteDialogViewController` 띄우고, '약관 동의' 화면으로 이동

https://github.com/LayTheGroundWork/A-Teen_iOS/assets/109324421/f4c1707d-9373-447a-b0c0-e71a1dde053a



### 이미 가입된 사용자 -> `ExistingUserLoginDialogViewController` 띄우고 -> '좋아요' 버튼 -> 로그인 된 상태로 '메인' 화면으로 이동
( * 로그인 처리는 추후에 viewmodel 로 연결하면 될 듯 -> 현재 ViewController 에서 분기 처리 )

https://github.com/LayTheGroundWork/A-Teen_iOS/assets/109324421/bde3dccc-51ef-4806-bdd8-6ba4d4cde786



### 이미 가입된 사용자 -> `ExistingUserLoginDialogViewController` 띄우고 -> '아니요' 버튼 -> 로그아웃 된 상태로 '메인' 화면으로 이동
( * 로그아웃 처리는 추후에 viewmodel 로 연결하면 될 듯 -> 현재 ViewController 에서 분기 처리 )

https://github.com/LayTheGroundWork/A-Teen_iOS/assets/109324421/d0c4544c-70bc-4456-b377-df8907b0eda8


<br/>


