### PR TITLE
Login view/phone number view: 인증코드 뷰 오류 수정

### DIFF
--- a/ATeen/ATeen/Scenes/Login/PhoneNumber/Presentation/Cell/CertificationCodeCollectionViewCell.swift
+++ b/ATeen/ATeen/Scenes/Login/PhoneNumber/Presentation/Cell/CertificationCodeCollectionViewCell.swift
@@ -23,16 +23,14 @@ final class CertificationCodeCollectionViewCell: UICollectionViewCell {
     private lazy var inputCodeLabel: UILabel = {
         let label = UILabel()
         label.text = AppLocalized.inputCodeText
-        label.font = UIFont.customFont(forTextStyle: .title3,
-                                       weight: .bold)
+        label.font = UIFont.customFont(forTextStyle: .title3, weight: .bold)
         label.textColor = .black
         return label
     }()
     
     private lazy var nextButton: UIButton = {
         let button = UIButton()
-        button.titleLabel?.font = UIFont.customFont(forTextStyle: .callout,
-                                                    weight: .regular)
+        button.titleLabel?.font = UIFont.customFont(forTextStyle: .callout, weight: .regular)
         button.setTitle(AppLocalized.nextButton, for: .normal)
         button.setTitleColor(.white, for: .normal)
         button.backgroundColor = .black
@@ -45,8 +43,7 @@ final class CertificationCodeCollectionViewCell: UICollectionViewCell {
     private lazy var resendLabel: UILabel = {
         let label = UILabel()
         label.text = AppLocalized.resendText
-        label.font = UIFont.customFont(forTextStyle: .footnote,
-                                       weight: .regular)
+        label.font = UIFont.customFont(forTextStyle: .footnote, weight: .regular)
         label.textColor = .gray02
         return label
     }()
@@ -54,8 +51,7 @@ final class CertificationCodeCollectionViewCell: UICollectionViewCell {
     private lazy var resendButton: UIButton = {
         let button = UIButton(type: .system)
         button.setTitle(AppLocalized.resendButtonText, for: .normal)
-        button.titleLabel?.font = UIFont.customFont(forTextStyle: .footnote,
-                                                    weight: .regular)
+        button.titleLabel?.font = UIFont.customFont(forTextStyle: .footnote, weight: .regular)
         button.setTitleColor(.main, for: .normal)
         button.addTarget(self, action: #selector(didSelectResendButton(_:)), for: .touchUpInside)
         return button
@@ -79,7 +75,6 @@ final class CertificationCodeCollectionViewCell: UICollectionViewCell {
         configLayout()
         setupActions()
     }
-    
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
@@ -216,28 +211,35 @@ extension CertificationCodeCollectionViewCell: UITextFieldDelegate {
     
     func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
         guard let text = textField.text, let textRange = Range(range, in: text) else { return false }
+        
+        // 텍스트가 숫자인지 확인
+        guard string.isEmpty || (string.rangeOfCharacter(from: CharacterSet.decimalDigits) != nil) else {
+            return false
+        }
 
         let updatedText = text.replacingCharacters(in: textRange, with: string)
-        
-        // 텍스트 필드에 텍스트 설정
-        textField.text = updatedText
         
         /// 입력이 비어 있는 경우 이전 텍스트 필드로 이동
         /// **현재 입력이 비어있어도 이전 텍스트 필드로 이동을 못하는 버그가 있음**
         if string.isEmpty {
-            if updatedText.isEmpty, textField.tag > 1 {
+            textField.text = ""
+            if textField.tag > 1 {
                 let previousTextField = textFields[textField.tag - 2]
                 previousTextField.becomeFirstResponder()
             }
         } else {
+            textField.text = String(string.prefix(1))
             // 입력 시 다음 필드로 이동
-            if updatedText.count == 1 {
-                if textField.tag < textFields.count {
-                    let nextTextField = textFields[textField.tag]
-                    nextTextField.becomeFirstResponder()
+            if textField.tag < textFields.count {
+                let nextTextField = textFields[textField.tag]
+                if nextTextField.text?.isEmpty == false {
+                    nextTextField.text = "" // 이미 값이 있을 경우 지우기
+                    nextTextField.becomeFirstResponder() // 그리고 포커스 이동
                 } else {
-                    textField.resignFirstResponder()
+                    nextTextField.becomeFirstResponder() // 빈 경우 바로 포커스 이동
                 }
+            } else {
+                textField.resignFirstResponder()
             }
         }
         

--- a/ATeen/ATeen/Scenes/Login/PhoneNumber/Presentation/Cell/CertificationCodeCollectionViewCell.swift
+++ b/ATeen/ATeen/Scenes/Login/PhoneNumber/Presentation/Cell/CertificationCodeCollectionViewCell.swift
@@ -90,7 +90,7 @@ final class CertificationCodeCollectionViewCell: UICollectionViewCell {
         self.contentView.addSubview(nextButton)
         
         for i in 0..<6 {
-            let textField = UITextField()
+            let textField = CustomTextField()
             textField.textAlignment = .center
             textField.font = UIFont.customFont(forTextStyle: .largeTitle, weight: .bold)
             textField.textColor = .black
@@ -200,6 +200,25 @@ final class CertificationCodeCollectionViewCell: UICollectionViewCell {
 
 // UITextFieldDelegate
 extension CertificationCodeCollectionViewCell: UITextFieldDelegate {
+    final class CustomTextField: UITextField {
+        override public func deleteBackward() {
+            if let text = text, text.isEmpty {
+                moveToPreviousTextField()
+            }
+            super.deleteBackward()
+        }
+        
+        private func moveToPreviousTextField() {
+            dump(self)
+            if tag > 1 {
+                // 이전 텍스트 필드로 이동
+                if let previousTextField = superview?.viewWithTag(tag - 1) as? UITextField {
+                    previousTextField.becomeFirstResponder()
+                }
+            }
+        }
+    }
+
     func textFieldDidBeginEditing(_ textField: UITextField) {
         updateBottomLineColors()
     }
@@ -209,19 +228,27 @@ extension CertificationCodeCollectionViewCell: UITextFieldDelegate {
         updateNextButtonState()
     }
     
-    func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
-        guard let text = textField.text, let textRange = Range(range, in: text) else { return false }
+    func textField(
+        _ textField: UITextField,
+        shouldChangeCharactersIn range: NSRange,
+        replacementString string: String
+    ) -> Bool {
+        guard let text = textField.text,
+              let textRange = Range(range, in: text) 
+        else {
+            return false
+        }
         
         // 텍스트가 숫자인지 확인
-        guard string.isEmpty || (string.rangeOfCharacter(from: CharacterSet.decimalDigits) != nil) else {
+        guard string.isEmpty ||
+                (string.rangeOfCharacter(from: CharacterSet.decimalDigits) != nil)
+        else {
             return false
         }
 
         let updatedText = text.replacingCharacters(in: textRange, with: string)
         
-        /// 입력이 비어 있는 경우 이전 텍스트 필드로 이동
-        /// **현재 입력이 비어있어도 이전 텍스트 필드로 이동을 못하는 버그가 있음**
-        if string.isEmpty {
+        if updatedText.isEmpty {
             textField.text = ""
             if textField.tag > 1 {
                 let previousTextField = textFields[textField.tag - 2]


### PR DESCRIPTION
- 제목 : Fix: 인증코드 뷰 버그 수정

## PR 유형
- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 🔎 작업 내용

- 텍스트필드 이전으로 돌아가게 되면 한 텍스트필드에 여러 값이 들어가는 버그 수정

- 숫자만 들어갈 수 있도록 텍스트필드 입력 값이 숫자인지 검증하는 로직 추가

- 텍스트 필드가 비어있을 때, backSpace 입력 시 이전 텍스트필드 포커스되는 로직 추가

  <br/>

## 이미지 첨부

![Simulator Screen Recording - iPhone 15 Pro - 2024-06-10 at 15 01 42](https://github.com/LayTheGroundWork/A-Teen_iOS/assets/37105602/fc1367a0-254d-4188-9d53-5be97f2abb93)
